### PR TITLE
Initialize-ISHRegional sets incorrect registry key for 'Long Time' format #17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Issues:
 - GH-13: Initialize-ISHRegional should not require elevated permissions.
+- GH-17: Initialize-ISHRegional sets incorrect registry key for 'Long Time' format.
 
 In detail:
 - `Initialize-ISHRegional` doesn't check for elevated permissions.

--- a/Source/Modules/ISHServer/Initialize-ISHRegional.ps1
+++ b/Source/Modules/ISHServer/Initialize-ISHRegional.ps1
@@ -37,7 +37,7 @@ function Initialize-ISHRegional
         Set-ItemProperty -Path "HKCU:\Control Panel\International" -Name sShortDate -Value "dd/MM/yyyy"
         Set-ItemProperty -Path "HKCU:\Control Panel\International" -Name sLongDate -Value "ddddd d MMMM yyyy"
         Set-ItemProperty -Path "HKCU:\Control Panel\International" -Name sShortTime -Value "HH:mm:ss"
-        Set-ItemProperty -Path "HKCU:\Control Panel\International" -Name sLongTime -Value "HH:mm:ss"
+        Set-ItemProperty -Path "HKCU:\Control Panel\International" -Name sTimeFormat -Value "HH:mm:ss"
         Write-Verbose "Set Formatters"
     }
     end

--- a/Source/Modules/ISHServer/Initialize-ISHRegionalDefault.ps1
+++ b/Source/Modules/ISHServer/Initialize-ISHRegionalDefault.ps1
@@ -38,7 +38,7 @@ function Initialize-ISHRegionalDefault
         Set-ItemProperty -Path "HKU:\.DEFAULT\Control Panel\International" -Name sShortDate -Value "dd/MM/yyyy"
         Set-ItemProperty -Path "HKU:\.DEFAULT\Control Panel\International" -Name sLongDate -Value "ddddd d MMMM yyyy"
         Set-ItemProperty -Path "HKU:\.DEFAULT\Control Panel\International" -Name sShortTime -Value "HH:mm:ss"
-        Set-ItemProperty -Path "HKU:\.DEFAULT\Control Panel\International" -Name sLongTime -Value "HH:mm:ss"
+        Set-ItemProperty -Path "HKU:\.DEFAULT\Control Panel\International" -Name sTimeFormat -Value "HH:mm:ss"
         Write-Verbose "Set Formatters  for DEFAULT account"
     }
     end


### PR DESCRIPTION
Issue #17
Replaced `sLongTime` with `sTimeFormat`